### PR TITLE
added default methods if you don't want to use a customScheme

### DIFF
--- a/Source/OIDAuthorizationRequest.h
+++ b/Source/OIDAuthorizationRequest.h
@@ -87,7 +87,7 @@ extern NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256;
 
 /*! @brief The client's custom redirect Scheme.
 */
-@property(nonatomic, readonly, nullable) NSString *customRedirectScheme;
+@property(nonatomic, readonly, nullable) NSURL *customRedirectURL;
 
 /*! @brief An opaque value used by the client to maintain state between the request and callback.
     @remarks state
@@ -145,11 +145,30 @@ extern NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256;
 - (instancetype)init NS_UNAVAILABLE;
 
 /*! @brief Creates an authorization request with opinionated defaults (a secure @c state, and
+ PKCE with S256 as the @c code_challenge_method).
+ @param configuration The service's configuration.
+ @param clientID The client identifier.
+ @param scopes An array of scopes to combine into a single scope string per the OAuth2 spec.
+ @param redirectURL The client's redirect URI.
+ @param responseType The expected response type.
+ @param additionalParameters The client's additional authorization parameters.
+ @remarks This convenience initializer generates a state parameter and PKCE challenges
+ automatically.
+ */
+- (instancetype) initWithConfiguration:(OIDServiceConfiguration *)configuration
+                              clientId:(NSString *)clientID
+                                scopes:(nullable NSArray<NSString *> *)scopes
+                           redirectURL:(NSURL *)redirectURL
+                          responseType:(NSString *)responseType
+                  additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
+
+/*! @brief Creates an authorization request with opinionated defaults (a secure @c state, and
         PKCE with S256 as the @c code_challenge_method).
     @param configuration The service's configuration.
     @param clientID The client identifier.
     @param scopes An array of scopes to combine into a single scope string per the OAuth2 spec.
     @param redirectURL The client's redirect URI.
+    @param customRedirectURL custom scheme
     @param responseType The expected response type.
     @param additionalParameters The client's additional authorization parameters.
     @remarks This convenience initializer generates a state parameter and PKCE challenges
@@ -160,9 +179,29 @@ extern NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256;
                  clientId:(NSString *)clientID
                    scopes:(nullable NSArray<NSString *> *)scopes
               redirectURL:(NSURL *)redirectURL
-             customRedirectScheme:(NSString *)customRedirectScheme
+             customRedirectURL:(nullable NSURL *)customRedirectURL
              responseType:(NSString *)responseType
      additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
+
+/*! @brief Creates an authorization request with opinionated defaults (a secure @c state, @c nonce,
+ and PKCE with S256 as the @c code_challenge_method).
+ @param configuration The service's configuration.
+ @param clientID The client identifier.
+ @param clientSecret The client secret.
+ @param scopes An array of scopes to combine into a single scope string per the OAuth2 spec.
+ @param redirectURL The client's redirect URI.
+ @param responseType The expected response type.
+ @param additionalParameters The client's additional authorization parameters.
+ @remarks This convenience initializer generates a state parameter and PKCE challenges
+ automatically.
+ */
+- (instancetype) initWithConfiguration:(OIDServiceConfiguration *)configuration
+                              clientId:(NSString *)clientID
+                          clientSecret:(NSString *)clientSecret
+                                scopes:(nullable NSArray<NSString *> *)scopes
+                           redirectURL:(NSURL *)redirectURL
+                          responseType:(NSString *)responseType
+                  additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
 
 /*! @brief Creates an authorization request with opinionated defaults (a secure @c state, @c nonce,
         and PKCE with S256 as the @c code_challenge_method).
@@ -171,6 +210,7 @@ extern NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256;
     @param clientSecret The client secret.
     @param scopes An array of scopes to combine into a single scope string per the OAuth2 spec.
     @param redirectURL The client's redirect URI.
+    @param customRedirectURL custom scheme
     @param responseType The expected response type.
     @param additionalParameters The client's additional authorization parameters.
     @remarks This convenience initializer generates a state parameter and PKCE challenges
@@ -182,9 +222,42 @@ extern NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256;
              clientSecret:(nullable NSString *)clientSecret
                    scopes:(nullable NSArray<NSString *> *)scopes
               redirectURL:(NSURL *)redirectURL
-           customRedirectScheme:(NSString *)customRedirectScheme
+           customRedirectURL:(nullable NSURL *)customRedirectURL
              responseType:(NSString *)responseType
      additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
+
+/*! @brief Designated initializer.
+ @param configuration The service's configuration.
+ @param clientID The client identifier.
+ @param scope A scope string per the OAuth2 spec (a space-delimited set of scopes).
+ @param redirectURL The client's redirect URI.
+ @param responseType The expected response type.
+ @param state An opaque value used by the client to maintain state between the request and
+ callback.
+ @param nonce String value used to associate a Client session with an ID Token. Can be set to nil
+ if not using OpenID Connect, although pure OAuth servers should ignore params they don't
+ understand anyway.
+ @param codeVerifier The PKCE code verifier. See @c OIDAuthorizationRequest.generateCodeVerifier.
+ @param codeChallenge The PKCE code challenge, calculated from the code verifier such as with
+ @c OIDAuthorizationRequest.codeChallengeS256ForVerifier:.
+ @param codeChallengeMethod The PKCE code challenge method.
+ ::OIDOAuthorizationRequestCodeChallengeMethodS256 when
+ @c OIDAuthorizationRequest.codeChallengeS256ForVerifier: is used to create the code
+ challenge.
+ @param additionalParameters The client's additional authorization parameters.
+ */
+- (instancetype) initWithConfiguration:(OIDServiceConfiguration *)configuration
+                              clientId:(NSString *)clientID
+                          clientSecret:(nullable NSString *)clientSecret
+                                 scope:(nullable NSString *)scope
+                           redirectURL:(nullable NSURL *)redirectURL
+                          responseType:(NSString *)responseType
+                                 state:(nullable NSString *)state
+                                 nonce:(nullable NSString *)nonce
+                          codeVerifier:(nullable NSString *)codeVerifier
+                         codeChallenge:(nullable NSString *)codeChallenge
+                   codeChallengeMethod:(nullable NSString *)codeChallengeMethod
+                  additionalParameters:(nullable NSDictionary<NSString *, NSString *> *)additionalParameters;
 
 /*! @brief Designated initializer.
     @param configuration The service's configuration.
@@ -212,7 +285,7 @@ extern NSString *const OIDOAuthorizationRequestCodeChallengeMethodS256;
              clientSecret:(nullable NSString *)clientSecret
                     scope:(nullable NSString *)scope
               redirectURL:(nullable NSURL *)redirectURL
-           customRedirectScheme:(NSString *)customRedirectScheme
+           customRedirectURL:(nullable NSURL *)customRedirectURL
              responseType:(NSString *)responseType
                     state:(nullable NSString *)state
                     nonce:(nullable NSString *)nonce

--- a/Source/OIDAuthorizationService.m
+++ b/Source/OIDAuthorizationService.m
@@ -90,15 +90,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)shouldHandleURL:(NSURL *)URL {
   NSURL *standardizedURL = [URL standardizedURL];
-  NSURL *standardizedRedirectURL = [_request.redirectURL standardizedURL];
 
+  BOOL shouldHandleUrl = false;
   //Added custom redirect scheme logic
-  return OIDIsEqualIncludingNil(standardizedURL.scheme, _request.customRedirectScheme) &&
-    OIDIsEqualIncludingNil(standardizedURL.user, standardizedRedirectURL.user) &&
+  if (_request.customRedirectURL != nil) {
+      NSURL* customRedirectURL = _request.customRedirectURL;
+    shouldHandleUrl = OIDIsEqualIncludingNil(standardizedURL.user, customRedirectURL.user) &&
+    OIDIsEqualIncludingNil(standardizedURL.password, customRedirectURL.password) &&
+    OIDIsEqualIncludingNil(standardizedURL.host, customRedirectURL.host) &&
+    OIDIsEqualIncludingNil(standardizedURL.port, customRedirectURL.port) &&
+    OIDIsEqualIncludingNil(standardizedURL.path, customRedirectURL.path);
+  } else {
+    NSURL *standardizedRedirectURL = [_request.redirectURL standardizedURL];
+    shouldHandleUrl = OIDIsEqualIncludingNil(standardizedURL.user, standardizedRedirectURL.user) &&
     OIDIsEqualIncludingNil(standardizedURL.password, standardizedRedirectURL.password) &&
     OIDIsEqualIncludingNil(standardizedURL.host, standardizedRedirectURL.host) &&
     OIDIsEqualIncludingNil(standardizedURL.port, standardizedRedirectURL.port) &&
     OIDIsEqualIncludingNil(standardizedURL.path, standardizedRedirectURL.path);
+  }
+    return shouldHandleUrl;
 }
 
 - (BOOL)resumeExternalUserAgentFlowWithURL:(NSURL *)URL {


### PR DESCRIPTION
- changed customScheme to customRedirectURL so that you can check for conformance of parameters

- For shouldHandleURL etc. check first if a customRedirectURL was provided - if not use the normal redirect url